### PR TITLE
Fixed typo on denominators related name and usage in templates

### DIFF
--- a/comet/migrations/0003_auto_20170714_1609.py
+++ b/comet/migrations/0003_auto_20170714_1609.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('comet', '0002_indicatorsettype_uuid'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='indicator',
+            name='denominators',
+            field=models.ManyToManyField(related_name='as_denominator', to='aristotle_mdr.DataElement', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='indicatorsettype',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid1, help_text='Universally-unique Identifier. Uses UUID1 as this improves uniqueness and tracking between registries', unique=True, editable=False),
+        ),
+    ]

--- a/comet/models.py
+++ b/comet/models.py
@@ -37,7 +37,7 @@ class Indicator(aristotle.models.concept):
     )
     denominators = models.ManyToManyField(
         aristotle.models.DataElement,
-        related_name="as_demoninator",
+        related_name="as_denominator",
         blank=True
     )
     disaggregators = models.ManyToManyField(

--- a/comet/templates/comet/extra_content/dataElement.html
+++ b/comet/templates/comet/extra_content/dataElement.html
@@ -1,7 +1,7 @@
 {% load aristotle_tags %}
 
 <h3>Use in indicators</h3>
-{% if item.as_numerator.exists  or item.denominators.exists or item.disaggregators.exists %}
+{% if item.as_numerator.exists or item.as_denominator.exists or item.as_disaggregator.exists %}
     This data element is included in the following Indicators, some indicators may be hidden based on your current permissions.
     {% if item.as_numerator.exists %}
     <h4>As a numerator</h4>


### PR DESCRIPTION
- Fixed related name of `denominators` property now using `as_denominator`
- Updated `dataElement.html` template to use `as_denominator` and `as_disaggregator` related names